### PR TITLE
Fixed the giveaway redirect link.

### DIFF
--- a/src/classes/giveaways.js
+++ b/src/classes/giveaways.js
@@ -231,7 +231,7 @@ class giveaways {
 	}
 }
 function replacePlaceholders(string, data, msg, winners = []) {
-	const newString = string.replace(/{guildName}/g, msg.guild.name).replace(/{prize}/g, data.prize).replace(/{giveawayURL}/g, `https://discord.com/${msg.guild.id}/${msg.channel.id}/${data.messageID}`).replace(/{hostedBy}/g, msg.guild.members.cache.get(data.host).toString()).replace(/{winners}/g, winners.length > 0 ? winners.map(winner => `<@${winner}>`).join(', ') : 'none' || 'none');
+	const newString = string.replace(/{guildName}/g, msg.guild.name).replace(/{prize}/g, data.prize).replace(/{giveawayURL}/g, `https://discord.com/channels/${msg.guild.id}/${msg.channel.id}/${data.messageID}`).replace(/{hostedBy}/g, msg.guild.members.cache.get(data.host).toString()).replace(/{winners}/g, winners.length > 0 ? winners.map(winner => `<@${winner}>`).join(', ') : 'none' || 'none');
 	return newString;
 }
 module.exports = giveaways;


### PR DESCRIPTION
Discord had updated the format of message links. So I updated it for you guys.

# Summary
Updated giveaway.js

# Extra details
Format of message has changed from `https://discord.com/${msg.guild.id}/${msg.channel.id}/${data.messageID}` to `https://discord.com/channels/${msg.guild.id}/${msg.channel.id}/${data.messageID}`